### PR TITLE
truncate kernel function name to 32 characters

### DIFF
--- a/src/hostside_opencl_funcs.cpp
+++ b/src/hostside_opencl_funcs.cpp
@@ -227,6 +227,9 @@ namespace cocl {
 
         CLKernel *kernel = 0;
         try {
+            if(kernelName.size() > 32) {
+                kernelName = kernelName.substr(0, 31);
+            }
             kernel = cl->buildKernelFromString(clSourcecode, kernelName, "", "__internal__");
         } catch(runtime_error &e) {
             cout << "failed to compile opencl sourcecode" << endl;


### PR DESCRIPTION
to match the fix with 4b3d457643eea97da54110de2c342c10e3f014ce
otherwise, unable to do clCreateKernel with the long name